### PR TITLE
Prevent icon overlapping text in headings

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -25,6 +25,8 @@
 // This expands upon styles in base.scss,
 // which expands upon styles in layout.scss
 
+@import "custom/headers";
+
 .input-group-button {
   button,
   .button {

--- a/app/assets/stylesheets/custom/_headers.scss
+++ b/app/assets/stylesheets/custom/_headers.scss
@@ -1,0 +1,39 @@
+// These rules that prevent overflowing of heading text in the headers, wrapping
+// the text instead. Some icons are positioned absolutely around the headings,
+// so we add a fixed padding to the right of the headings. Because the height of
+// the header is now flexible, we also need to need make sure the icons are
+// always vertically centered without using hardcoded positions.
+
+.debate-new .header,
+.proposal-form .header,
+.budget-investment-new .header {
+  h1, h2 {
+    @include breakpoint(medium) {
+      padding-right: rem-calc(200);
+    }
+
+    @include breakpoint(large) {
+      padding-right: rem-calc(240);
+    }
+  }
+
+  @include breakpoint(large) {
+    .header-icon ~ h1, .header-icon ~ h2 {
+      padding-right: rem-calc(360);
+    }
+
+    .header-icon, &.header-single-heading .header-icon {
+      top: calc(50% - #{rem-calc(30)});
+    }
+  }
+
+
+  @include breakpoint(medium) {
+    &.header-single-heading::after, &::after {
+      padding-top: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+  }
+}


### PR DESCRIPTION
This patch fixes an issue in which the icon in a header overlaps the heading text, fixed by wrapping the text over multiple lines instead. Since the icons are positioned absolutely, we also need to include some hardcoded paddings to take these into account.

**Before**

<img width="1385" alt="Screenshot 2022-01-19 at 11 18 30" src="https://user-images.githubusercontent.com/70964/150111358-7922dd7a-5206-4e4d-b977-18660bbe7fda.png">

**After**

<img width="1385" alt="Screenshot 2022-01-19 at 11 18 47" src="https://user-images.githubusercontent.com/70964/150111378-003eb889-fe03-4c78-87e6-e2033b70832d.png">